### PR TITLE
feat: org-wide governance setup

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1,0 +1,21 @@
+# rararulab — Organization Agent Guidelines
+
+## Purpose
+Central governance repo for rararulab. Files here are inherited by all repos in the org.
+
+## Structure
+- `CLAUDE.md` — Org-wide AI agent baseline rules
+- `docs/` — Shared development guides (workflow, code style, commit conventions)
+- `ISSUE_TEMPLATE/` — Inherited issue templates for all repos
+- `pull_request_template.md` — Inherited PR template
+- `CONTRIBUTING.md` — Inherited contribution guidelines
+- `profile/README.md` — Org profile page
+
+## Key Invariants
+- Issue templates use a generic component dropdown — repos override with their own if needed
+- All docs are in English
+- CLAUDE.md is the baseline; individual repos extend it with repo-specific rules
+
+## What NOT To Do
+- Do NOT add repo-specific rules here — those belong in each repo's own CLAUDE.md
+- Do NOT remove templates without checking which repos depend on inheritance

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,17 @@
+# CLAUDE.md — rararulab Organization Standards
+
+## Communication
+- 用中文与用户交流
+
+## Development Workflow
+@docs/workflow.md
+@docs/stacked-prs.md
+@docs/commit-style.md
+
+## Code Quality
+@docs/rust-style.md
+@docs/code-comments.md
+@docs/agent-md.md
+
+## Guardrails
+@docs/anti-patterns.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,22 @@
+# Contributing to rararulab
+
+Thank you for contributing! Please follow these guidelines:
+
+## Development Workflow
+
+All changes follow the **issue → worktree → PR → merge** flow. See [workflow guide](docs/workflow.md).
+
+## Commit Style
+
+We use [Conventional Commits](https://www.conventionalcommits.org/). See [commit style guide](docs/commit-style.md).
+
+## Code Style
+
+- Rust: See [Rust style guide](docs/rust-style.md)
+- All comments and docs in English: See [code comments guide](docs/code-comments.md)
+
+## Issues and PRs
+
+- Use the issue templates provided
+- Include type + component labels on all issues and PRs
+- Wait for CI to pass before requesting review

--- a/ISSUE_TEMPLATE/bug_report.yml
+++ b/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,51 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+labels: ["bug"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What happened? What did you expect?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which part of the system is affected?
+      options:
+        - core (runtime, engine, core logic)
+        - backend (API, server, services)
+        - frontend (web UI, dashboard)
+        - cli (command-line interface)
+        - ci (CI/CD, build, release)
+        - docs (documentation)
+        - other
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps to reproduce the issue
+      placeholder: |
+        1. Run `...`
+        2. Send request to ...
+        3. Observe error ...
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / Error output
+      description: Relevant log output or error messages
+      render: shell
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: Output of the relevant version command
+      placeholder: "v0.1.0"

--- a/ISSUE_TEMPLATE/chore.yml
+++ b/ISSUE_TEMPLATE/chore.yml
@@ -1,0 +1,26 @@
+name: Chore / Maintenance
+description: CI, dependencies, tooling, or other maintenance tasks
+labels: ["chore"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What maintenance work is needed?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: What area does this affect?
+      options:
+        - ci (GitHub Actions, workflows)
+        - dependencies (crate updates, npm updates)
+        - tooling (dev tooling, scripts)
+        - release (versioning, changelog, publishing)
+        - documentation
+        - other
+    validations:
+      required: true

--- a/ISSUE_TEMPLATE/config.yml
+++ b/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/ISSUE_TEMPLATE/feature_request.yml
+++ b/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,33 @@
+name: Feature Request
+description: Suggest a new feature or enhancement
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What do you want and why?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which part of the system does this relate to?
+      options:
+        - core (runtime, engine, core logic)
+        - backend (API, server, services)
+        - frontend (web UI, dashboard)
+        - cli (command-line interface)
+        - ci (CI/CD, build, release)
+        - docs (documentation)
+        - other
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you've thought about

--- a/ISSUE_TEMPLATE/refactor.yml
+++ b/ISSUE_TEMPLATE/refactor.yml
@@ -1,0 +1,33 @@
+name: Refactor
+description: Propose a code refactor or technical improvement
+labels: ["refactor"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What needs refactoring and why?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which part of the system is affected?
+      options:
+        - core (runtime, engine, core logic)
+        - backend (API, server, services)
+        - frontend (web UI, dashboard)
+        - cli (command-line interface)
+        - ci (CI/CD, build, release)
+        - docs (documentation)
+        - other
+    validations:
+      required: true
+
+  - type: textarea
+    id: approach
+    attributes:
+      label: Proposed approach
+      description: How would you approach this refactor?

--- a/docs/agent-md.md
+++ b/docs/agent-md.md
@@ -1,0 +1,39 @@
+# AGENT.md Requirements
+
+Every crate and significant module directory MUST have an `AGENT.md` file that guides AI agents working in that area. This is mandatory for new crates and expected to be added incrementally for existing ones.
+
+## When to Create
+
+- **New crate/package**: `AGENT.md` is required at the package root before the PR can merge
+- **New major module**: If a subdirectory has its own domain logic, add an `AGENT.md` there
+- **Significant refactor**: If you restructure internals, update or create the `AGENT.md`
+
+## Template
+
+```markdown
+# {package-name} — Agent Guidelines
+
+## Purpose
+One sentence: what this package does and why it exists.
+
+## Architecture
+Key modules, data flow, and public API surface. Point to real source files rather than abstract descriptions.
+
+## Critical Invariants
+Constraints that MUST NOT be violated (thread safety, ordering guarantees, security boundaries).
+Explain the consequence of violation.
+
+## What NOT To Do
+Explicit anti-patterns with reasoning. Format: "Do NOT X — because Y".
+
+## Dependencies
+Upstream/downstream package relationships and external service dependencies.
+```
+
+## Rules
+
+- Keep each `AGENT.md` under 300 lines — only include what an agent cannot infer from reading the code
+- Write in English
+- Executable commands and real file paths over abstract descriptions
+- Update `AGENT.md` in the same PR when you change the package's architecture or invariants
+- Do NOT let AI auto-generate `AGENT.md` from scratch — the author (human or agent who built the feature) writes it based on actual design decisions

--- a/docs/anti-patterns.md
+++ b/docs/anti-patterns.md
@@ -1,0 +1,25 @@
+# What NOT To Do
+
+## Code & Architecture
+- Do NOT use manual `impl Display` + `impl Error` — use `snafu`
+- Do NOT use mock repositories in tests — use `testcontainers`
+- Do NOT use noop/hollow trait implementations — trait methods with real implementations must not have default empty bodies (silently return `Ok(())` / `Ok(None)` / `vec![]`). Optional UX hooks (`typing_indicator`, lifecycle hooks) are the only exception
+- Do NOT write manual `fn new()` constructors for structs with 3+ fields — use `#[derive(bon::Builder)]` and construct via `Foo::builder().field(val).build()`. Config structs must also derive `Deserialize` and never `#[derive(Default)]`
+- Do NOT hardcode database URLs or config defaults in Rust code — use a config file
+- Do NOT modify already-applied migration files — create a new migration instead
+- Do NOT write code comments in any language other than English
+
+## Workflow
+- Do NOT work directly on `main` — ALL changes (code, docs, config) require a worktree + PR, no exceptions
+- Do NOT merge locally on `main` — all merges go through GitHub PRs; never `git merge` or `git commit` on main
+- Do NOT edit files in the main checkout for 'quick fixes' — even one-line changes must go through the full issue → worktree → PR flow
+- Do NOT create issues without the appropriate agent label (`agent:claude`, `agent:codex`, etc.)
+- Do NOT create PRs or issues without type + component labels — every PR and issue must have a type label (`bug`, `enhancement`, `refactor`, `chore`, `documentation`) and a component label (`core`, `backend`, `frontend`, `cli`, `ci`, `docs`)
+- Do NOT leave stale worktrees — clean up after PR is merged
+- Do NOT report PR as complete before CI is green — use `gh pr checks --watch` and fix failures before reporting
+- Do NOT create a new crate/package without an `AGENT.md` — every package must ship with agent guidelines from day one
+
+## Agent System Prompt
+- Do NOT add "plan before act" rules to agent system prompts — this causes redundant/repetitive narrative text even for simple interactions (hello). The correct principle is "act first, report after"
+- Do NOT use overly broad conditions to trigger memory search — "proactively search memory" causes every interaction to trigger search + meaningless narrative. Trigger conditions must be explicitly scoped (e.g., "user explicitly asks about past events")
+- Do NOT modify agent system prompts without testing — at minimum, verify with simple inputs like "hello" that no abnormal/repetitive output is produced

--- a/docs/code-comments.md
+++ b/docs/code-comments.md
@@ -1,0 +1,7 @@
+# Code Comments
+
+- All new or modified public items (`pub fn`, `pub struct`, `pub enum`, `pub trait`) MUST have English doc comments (`///`)
+- Add inline comments to explain **why**, not **what** — skip comments that merely restate the code
+- Do NOT retroactively add comments to unchanged code — only comment what you touch
+- Complex algorithms, non-obvious invariants, and safety-critical logic require comments even on private items
+- All comments, doc comments, and string literals must be in English

--- a/docs/commit-style.md
+++ b/docs/commit-style.md
@@ -1,0 +1,19 @@
+# Commit Style — Conventional Commits (MANDATORY)
+
+Every commit message MUST follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>(<scope>): <description> (#N)
+
+<optional body>
+
+Closes #N
+```
+
+- **Allowed types**: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `ci`, `perf`, `style`, `build`, `revert`
+- **Scope** matches module or area: `feat(core):`, `fix(api):`, `refactor(auth):`
+- **Breaking changes** use `!`: `feat(api)!: remove deprecated endpoint`
+- Include `(#N)` issue reference in commit subject
+- Include `Closes #N` in commit body
+- If the project has a `commit-msg` hook, do NOT bypass it
+- Do NOT use free-form commit messages like `"update code"` or `"fix stuff"` — they will be rejected

--- a/docs/rust-style.md
+++ b/docs/rust-style.md
@@ -1,0 +1,107 @@
+# Rust Code Style
+
+## Error Handling
+
+- Use `snafu` exclusively — never `thiserror` or manual `impl Error`
+- `anyhow` allowed at application boundaries (tool implementations, integrations, app bootstrap) but NOT in domain/core logic — use `snafu` there
+- Every error enum: `#[derive(Debug, Snafu)]` + `#[snafu(visibility(pub))]`
+- Name: `{CrateName}Error`, variants use `#[snafu(display("..."))]`
+- Propagate with `.context(XxxSnafu)?` or `.whatever_context("msg")?`
+- Define `pub type Result<T> = std::result::Result<T, CrateError>` per crate
+
+## Type Patterns
+
+- Trait objects: always create `pub type XRef = Arc<dyn X>` alias
+- No hardcoded config defaults in Rust — all via YAML
+
+## Struct Construction — Use `bon::Builder`
+
+Structs with 3+ fields MUST use `#[derive(bon::Builder)]` — do NOT write manual `fn new()` constructors.
+
+**Rules:**
+- `#[derive(bon::Builder)]` on any struct with 3+ fields (config, domain objects, options, etc.)
+- Config structs: always pair with `Deserialize`, never `#[derive(Default)]` — defaults come from YAML
+- Do NOT write `impl Foo { pub fn new(a, b, c, d, ...) -> Self }` — use the generated builder instead
+- Cross-module construction: use `Foo::builder().field(val).build()`, not struct literals
+- Within the defining module, struct literals are fine when all fields are straightforward
+- `Option<T>` fields automatically default to `None` in bon — no need for `#[builder(default)]`
+- For non-Option defaults, use `#[builder(default = value)]`
+- Simple 1-2 field structs can use direct construction (no builder needed)
+
+```rust
+// Good: derive builder + Deserialize for config
+#[derive(Debug, Clone, bon::Builder, Serialize, Deserialize)]
+pub struct ServerConfig {
+    pub host: String,
+    pub port: u16,
+    pub max_connections: usize,
+    pub tls_enabled: bool,
+}
+
+// Good: construct via builder (especially from outside the module)
+let config = ServerConfig::builder()
+    .host("0.0.0.0".into())
+    .port(8080)
+    .max_connections(100)
+    .tls_enabled(true)
+    .build();
+
+// Bad: manual constructor — use the generated builder
+impl ServerConfig {
+    pub fn new(host: String, port: u16, max_connections: usize, tls_enabled: bool) -> Self {
+        Self { host, port, max_connections, tls_enabled }
+    }
+}
+```
+
+## Async
+
+- `#[async_trait]` + `Send + Sync` bound on async trait definitions
+- Logging: `tracing` macros + `#[instrument(skip_all)]`
+
+## Functional Style
+
+Prefer functional programming patterns over imperative code:
+
+- **Iterator chains** over `for` loops with manual accumulation — use `.map()`, `.filter()`, `.flat_map()`, `.fold()`, `.collect()`
+- **Early returns with `?`** over nested `if let` / `match` — keep the happy path flat
+- **Combinators on Option/Result** — `.map()`, `.and_then()`, `.unwrap_or_else()`, `.ok_or_else()` over `match` when the logic is a simple transform
+- **`match` for complex branching** — use `match` when there are 3+ arms or when destructuring is needed; don't force combinators into unreadable chains
+- **Closures** for short inline logic; extract to named functions when the closure exceeds ~5 lines
+- **Immutable by default** — only use `mut` when mutation is genuinely needed
+- **`let` bindings for intermediate results** — name intermediate values to improve readability rather than chaining everything into one expression
+- Avoid side effects in iterator chains — if you need side effects, use `for` or `.for_each()`
+
+```rust
+// Good: functional chain
+let active_names: Vec<_> = users
+    .iter()
+    .filter(|u| u.is_active)
+    .map(|u| &u.name)
+    .collect();
+
+// Bad: imperative accumulation
+let mut active_names = Vec::new();
+for u in &users {
+    if u.is_active {
+        active_names.push(&u.name);
+    }
+}
+
+// Good: combinator on Option
+let display = user.nickname.as_deref().unwrap_or(&user.name);
+
+// Bad: match for simple default
+let display = match &user.nickname {
+    Some(n) => n.as_str(),
+    None => &user.name,
+};
+```
+
+## Code Organization
+
+- Split logic into sub-files; `mod.rs` only for re-exports + `//!` module docs
+- Imports grouped: `std` → external crates → internal (`crate::` / `super::`)
+- No wildcard imports (`use foo::*`)
+- All `pub` items must have `///` doc comments in English
+- Use `.expect("context")` over `unwrap()` in non-test code

--- a/docs/stacked-prs.md
+++ b/docs/stacked-prs.md
@@ -1,0 +1,155 @@
+# Stacked PRs for Large Features
+
+When a feature is too large for a single PR (> ~400 lines of change, or spans multiple modules/layers), use stacked PRs to break it into reviewable increments.
+
+**When to use**: Only for large features that benefit from incremental decomposition. Small/independent tasks continue using the [standard workflow](workflow.md).
+
+```
+1. CREATE EPIC ISSUE  →  gh issue create for the overall feature
+2. CREATE FEATURE BRANCH  →  git branch feat/{name} main
+3. DECOMPOSE  →  Create sub-issues for each incremental step
+4. STACK  →  Each sub-issue branches off the previous one (not main)
+5. INCREMENTAL PRs  →  Each sub-PR targets the previous branch in the stack
+6. FINAL PR  →  One summary PR from feat/{name} → main for boss review
+```
+
+## Step 1: Create Epic Issue
+
+Use the appropriate issue template (see [workflow](workflow.md) for template list):
+```bash
+gh issue create --template feature_request.yml \
+  --title "feat(scope): large feature description" \
+  --body "$(cat <<'EOF'
+### Description
+Overall feature description and motivation.
+
+### Component
+core (runtime, engine, core logic)
+
+### Alternatives considered
+N/A
+EOF
+)" --label "agent:claude" --label "core"
+```
+This is the tracking issue (e.g., #100). All sub-issues reference it.
+
+## Step 2: Create Feature Base Branch
+```bash
+git checkout main && git pull
+git branch feat/{name} main
+git push -u origin feat/{name}
+```
+
+## Step 3: Decompose into Sub-Issues
+Create one issue per incremental step, referencing the epic:
+```bash
+gh issue create --template feature_request.yml \
+  --title "feat(scope): step 1 — add data model (#100)" \
+  --body "$(cat <<'EOF'
+### Description
+Part of #100. Add the data model layer.
+
+### Component
+core (runtime, engine, core logic)
+
+### Alternatives considered
+N/A
+EOF
+)" --label "agent:claude" --label "core"
+```
+
+## Step 4: Stack Branches and Work
+Each sub-issue gets a worktree branching off the previous step:
+```bash
+# Step 1: branches from feat/{name}
+git worktree add .worktrees/issue-101-step1 -b issue-101-step1 feat/{name}
+
+# Step 2: branches from step 1 (after step 1 is done)
+git worktree add .worktrees/issue-102-step2 -b issue-102-step2 issue-101-step1
+```
+
+## Step 5: Incremental PRs
+Each sub-PR targets the previous branch in the stack. Use the PR template (`.github/pull_request_template.md`):
+```bash
+# Step 1 PR: targets feat/{name}
+gh pr create --base feat/{name} --title "feat(scope): step 1 — add data model (#101)" \
+  --body "$(cat <<'EOF'
+## Summary
+Part of #100. Add data model for the new feature.
+
+## Type of change
+| Type | Label |
+|------|-------|
+| New feature | `enhancement` |
+
+## Component
+`core`
+
+## Closes
+Closes #101
+
+## Test plan
+- [x] Tests pass
+- [x] Lints pass
+- [x] Tested locally
+EOF
+)" --label "enhancement" --label "core"
+
+# Step 2 PR: targets step 1 branch
+gh pr create --base issue-101-step1 --title "feat(scope): step 2 — add service layer (#102)" \
+  --body "$(cat <<'EOF'
+## Summary
+Part of #100. Add service layer on top of the data model.
+
+## Type of change
+| Type | Label |
+|------|-------|
+| New feature | `enhancement` |
+
+## Component
+`core`
+
+## Closes
+Closes #102
+
+## Test plan
+- [x] Tests pass
+- [x] Lints pass
+- [x] Tested locally
+EOF
+)" --label "enhancement" --label "core"
+```
+- Merge sub-PRs in order (step 1 first, then step 2, etc.)
+- After merging a sub-PR, update the next PR's base if needed: `gh pr edit {N} --base feat/{name}`
+
+## Step 6: Final Summary PR
+After all sub-PRs are merged into `feat/{name}`, create the summary PR:
+```bash
+gh pr create --base main --head feat/{name} \
+  --title "feat(scope): large feature description (#100)" \
+  --body "$(cat <<'EOF'
+## Summary
+Complete implementation of the feature.
+- Step 1: Added data model (#101)
+- Step 2: Added service layer (#102)
+- Step 3: Added API endpoints (#103)
+
+## Type of change
+| Type | Label |
+|------|-------|
+| New feature | `enhancement` |
+
+## Component
+`core`
+
+## Closes
+Closes #100
+
+## Test plan
+- [x] Tests pass
+- [x] Lints pass
+- [x] Tested locally
+EOF
+)" --label "enhancement" --label "core"
+```
+This is the **only PR the reviewer needs to look at** — a single, complete view of the entire feature.

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -1,0 +1,158 @@
+# Development Workflow — Issue → Worktree → PR → Merge
+
+**Every code change — no matter how small — MUST follow this workflow.** There are zero exceptions: single-line fixes, typo corrections, config tweaks, doc updates, and refactors all go through issue + worktree + PR. The main agent must NEVER directly edit source files on the `main` branch.
+
+```
+1. CREATE ISSUE    →  gh issue create + labels
+2. CREATE WORKTREE →  git worktree add .worktrees/issue-{N}-{name} -b issue-{N}-{name}
+3. WORK            →  All edits happen inside the worktree
+4. VERIFY          →  Build + lint checks on worktree
+5. PUSH & PR       →  git push -u origin + gh pr create
+6. CLEANUP         →  git worktree remove + git branch -d (after PR merged)
+```
+
+## Step 1: Create Issue
+
+Issues MUST use the GitHub issue templates defined in `.github/ISSUE_TEMPLATE/`. Pick the template matching the change type:
+
+| Template | Use when |
+|----------|----------|
+| `feature_request.yml` | New feature or enhancement |
+| `bug_report.yml` | Bug fix |
+| `refactor.yml` | Code refactor or technical improvement |
+| `chore.yml` | CI, dependencies, tooling, maintenance |
+
+```bash
+# Example: feature request
+gh issue create --template feature_request.yml \
+  --title "feat(scope): short description" \
+  --body "$(cat <<'EOF'
+### Description
+What you want and why.
+
+### Component
+core (runtime, engine, core logic)
+
+### Alternatives considered
+None.
+EOF
+)" --label "agent:claude" --label "core"
+
+# Example: bug report
+gh issue create --template bug_report.yml \
+  --title "fix(scope): short description" \
+  --body "$(cat <<'EOF'
+### Description
+What happened and what you expected.
+
+### Component
+backend (API, server, services)
+
+### Steps to reproduce
+1. ...
+2. ...
+
+### Logs / Error output
+...
+EOF
+)" --label "agent:claude" --label "backend"
+```
+
+**Issue Labels** (all issues MUST have proper labels):
+- **Agent** (required for agent-created issues): `agent:claude`, `agent:codex` — use the label matching the agent performing the operation
+- **Type**: auto-applied by the template (`enhancement`, `bug`, `refactor`, `chore`)
+- **Component** (pick one): `core`, `backend`, `frontend`, `cli`, `ci`, `docs`
+
+## Step 2: Create Worktree
+```bash
+git worktree add .worktrees/issue-{N}-{short-name} -b issue-{N}-{short-name}
+```
+
+## Step 3: Work in Worktree
+- **All code edits happen exclusively inside the worktree directory** — never in the main checkout
+- The main agent may dispatch a subagent to the worktree, or work there directly
+- Independent issues can be dispatched **in parallel** (each in its own worktree)
+- All work should be committed before moving to the next step
+
+## Step 4: Verify Builds
+After work is complete, verify in the worktree. The exact commands depend on the project:
+```bash
+# Rust projects
+cargo check -p {crate-name}
+cargo clippy --workspace --all-targets --all-features --no-deps -- -D warnings
+
+# Frontend projects
+npm run build
+npm run lint
+
+# Or use the project's task runner (just, make, etc.)
+```
+
+## Pre-commit Checks
+
+If the project uses pre-commit hooks (e.g., [prek](https://github.com/j178/prek)), the **final commit** in any PR must pass all checks — intermediate commits during development don't need to pass.
+
+If pre-commit hook blocks a commit during development, fix issues before the final commit. Do NOT use `--no-verify` to skip hooks.
+
+## Step 5: Push & Create PR
+
+PRs use the template at `.github/pull_request_template.md`. Fill in all sections.
+
+```bash
+git push -u origin issue-{N}-{short-name}
+gh pr create --title "fix(scope): description (#N)" --body "$(cat <<'EOF'
+## Summary
+
+Brief description of the changes.
+
+## Type of change
+
+| Type | Label |
+|------|-------|
+| Bug fix | `bug` |
+
+## Component
+
+`core`
+
+## Closes
+
+Closes #N
+
+## Test plan
+
+- [x] Tests pass
+- [x] Lints pass
+- [x] Tested locally
+EOF
+)" --label "bug" --label "core"
+```
+- Commit message must include `Closes #N` so the issue is auto-closed when PR merges
+- Never merge locally — all merges happen through GitHub PR
+- **PR Labels** (all PRs MUST have proper labels):
+  - **Type** (pick one): `bug`, `enhancement`, `refactor`, `chore`, `documentation`
+  - **Component** (pick one): `core`, `backend`, `frontend`, `cli`, `ci`, `docs`
+
+## Step 5.5: Wait for CI Green (MANDATORY)
+
+After creating the PR, **you MUST verify that all CI checks pass before reporting completion to the user.**
+
+```bash
+gh pr checks {PR-number} --watch    # Wait for all checks to complete
+```
+
+- If any check fails, investigate and fix in the worktree, push again, and re-verify
+- Do NOT report "PR created" or "task done" to the user while CI is still pending or failing
+- Only after all checks are green may you inform the user that the PR is ready
+
+## Step 6: Cleanup (after PR merged)
+```bash
+git worktree remove .worktrees/issue-{N}-{short-name}
+git branch -d issue-{N}-{short-name}
+```
+
+## Parallel Execution
+
+When user requests involve multiple independent changes, split into separate issues and dispatch subagents in parallel:
+- Each subagent gets its own worktree, branch, and PR
+- PRs are reviewed and merged independently on GitHub

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,35 @@
+## Summary
+
+<!-- Brief description of the changes -->
+
+## Type of change
+
+<!-- Check the one that applies and add the matching label to this PR -->
+
+| Type | Label |
+|------|-------|
+| Bug fix | `bug` |
+| New feature | `enhancement` |
+| Breaking change | `breaking-change` |
+| Refactor | `refactor` |
+| CI / Infrastructure | `ci` |
+| Maintenance | `chore` |
+| Documentation | `documentation` |
+
+## Component
+
+<!-- Add the component label that best matches the area you changed -->
+<!-- `core` · `backend` · `frontend` · `cli` · `ci` · `docs` -->
+
+## Closes
+
+<!-- REQUIRED: Link the issue this PR resolves. PR merge will auto-close the issue. -->
+<!-- If no issue exists, create one first: gh issue create -->
+
+Closes #
+
+## Test plan
+
+- [ ] Tests pass
+- [ ] Lints pass
+- [ ] Tested locally


### PR DESCRIPTION
## Summary

Establishes rararulab org-level governance in the .github repo:
- `CLAUDE.md` — Org-wide AI agent baseline
- `AGENT.md` — Repo-level agent guidelines
- `docs/` — Shared guides (workflow, commit style, Rust style, code comments, anti-patterns, agent-md, stacked PRs)
- `ISSUE_TEMPLATE/` — Generic issue templates inherited by all repos
- `pull_request_template.md` — Generic PR template
- `CONTRIBUTING.md` — Contribution guidelines

All files are generalized from rara's battle-tested configs.

## Type of change

| Type | Label |
|------|-------|
| New feature | `enhancement` |

## Test plan

- [x] Templates are valid YAML
- [x] Docs are complete and in English
- [ ] Verify inheritance works on a repo without its own templates