### PR TITLE
feat(bdd): add BDD issue template and reusable CI workflow (#6)

### DIFF
--- a/ISSUE_TEMPLATE/bdd_task.yml
+++ b/ISSUE_TEMPLATE/bdd_task.yml
@@ -18,6 +18,29 @@ body:
       required: true
 
   - type: textarea
+    id: plan-spec
+    attributes:
+      label: Plan Spec
+      description: |
+        Product context, deliverables, constraints, and out of scope.
+        The implementation agent reads this to understand WHY the feature exists.
+      placeholder: |
+        **Product context:** Why this feature exists, what user problem it solves.
+
+        **Deliverables:**
+        - [ ] Deliverable 1 — brief description
+        - [ ] Deliverable 2 — brief description
+
+        **Constraints:**
+        - Constraint 1
+
+        **Out of scope:**
+        - Thing explicitly excluded
+      render: markdown
+    validations:
+      required: true
+
+  - type: textarea
     id: feature-file
     attributes:
       label: ".feature (Acceptance Criteria)"

--- a/ISSUE_TEMPLATE/bdd_task.yml
+++ b/ISSUE_TEMPLATE/bdd_task.yml
@@ -1,0 +1,89 @@
+name: BDD Task
+description: Feature or bugfix with BDD acceptance criteria (for agent-driven workflow)
+labels: ["bdd", "enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This template is for the **agent-driven BDD workflow**.
+        Provide complete Gherkin scenarios so that `rara-bdd` can generate
+        step definitions and the CI pipeline can validate coverage.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What and why?
+    validations:
+      required: true
+
+  - type: textarea
+    id: feature-file
+    attributes:
+      label: Feature file
+      description: |
+        Complete Gherkin scenarios. Minimum 3 scenarios (happy path + error + edge case).
+        Use @AC-XX tags for each scenario. Use concrete Given/When/Then steps.
+      placeholder: |
+        @module-name
+        Feature: Short feature title
+
+          @AC-01
+          Scenario: Happy path
+            Given ...
+            When ...
+            Then ...
+
+          @AC-02
+          Scenario: Error case
+            Given ...
+            When ...
+            Then ...
+
+          @AC-03
+          Scenario: Edge case
+            Given ...
+            When ...
+            Then ...
+      render: text
+    validations:
+      required: true
+
+  - type: textarea
+    id: design-spec
+    attributes:
+      label: Design spec
+      description: Files to create/modify, interfaces, constraints
+      render: markdown
+    validations:
+      required: true
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which part of the system does this relate to?
+      options:
+        - core (runtime, engine, core logic)
+        - backend (API, server, services)
+        - frontend (web UI, dashboard)
+        - cli (command-line interface)
+        - ci (CI/CD, build, release)
+        - docs (documentation)
+        - other
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: Affected modules and directories
+    validations:
+      required: true
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Additional context
+      description: Any other information that might be helpful

--- a/workflows/bdd.yml
+++ b/workflows/bdd.yml
@@ -1,0 +1,48 @@
+name: BDD Tests
+
+on:
+  workflow_call:
+    inputs:
+      features-dir:
+        description: "Path to features directory"
+        required: false
+        type: string
+        default: "features"
+      steps-dir:
+        description: "Path to step definitions directory"
+        required: false
+        type: string
+        default: "tests/steps"
+      rust-toolchain:
+        description: "Rust toolchain to use"
+        required: false
+        type: string
+        default: "stable"
+
+permissions:
+  contents: read
+
+jobs:
+  bdd:
+    name: BDD Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ inputs.rust-toolchain }}
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-bdd-${{ hashFiles('**/Cargo.lock') }}
+      - name: Install rara-bdd
+        run: cargo install --git https://github.com/rararulab/rara-bdd
+      - name: Check step coverage
+        run: rara-bdd coverage --features-dir ${{ inputs.features-dir }} --steps-dir ${{ inputs.steps-dir }}
+      - name: Run BDD tests
+        run: cargo test --test bdd


### PR DESCRIPTION
## Summary

- Create `bdd_task.yml` issue template for agent-driven BDD workflow (description, .feature, design spec, component, scope)
- Create `bdd.yml` reusable CI workflow (`workflow_call`) that runs `rara-bdd coverage` + `cargo test --test bdd`

## Test plan

- [ ] `bdd_task.yml` renders correctly in GitHub issue creation UI
- [ ] `bdd.yml` can be called from other repos via `workflow_call`
- [ ] CI workflow installs rara-bdd and runs coverage + BDD tests

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)